### PR TITLE
Add Robot Color Jam puzzle game

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,7 @@ rad.json
 *.flf
 #Test results file
 TestResults.xml
+# Node
+node_modules/
+dist/
+.env

--- a/README.md
+++ b/README.md
@@ -1,0 +1,20 @@
+# Robot Color Jam
+
+This is a simple puzzle game inspired by **Color Block Jam**. Guide each colored robot to the matching charging station located on the edges of the board.
+
+The project uses **React**, **TypeScript**, and **Vite** so it can be easily run on environments like StackBlitz.
+
+## Available Scripts
+
+- `npm run dev` - start the development server
+- `npm run build` - create a production build
+- `npm run preview` - preview the production build
+
+## Game Description
+
+- Select a robot by clicking on it. The active robot glows.
+- Use the directional buttons to slide the robot until it hits an obstacle.
+- Robots exiting through their matching station are removed from the board.
+- Clear all robots to move to the next level.
+
+Three sample levels are included with increasing difficulty. Feel free to extend `src/game/levels.ts` to add more!

--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Robot Color Jam</title>
+</head>
+<body>
+  <div id="root"></div>
+  <script type="module" src="/src/main.tsx"></script>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "robot-color-jam",
+  "version": "1.0.0",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.0.0",
+    "@types/react-dom": "^18.0.0",
+    "typescript": "^5.0.0",
+    "vite": "^5.0.0",
+    "@vitejs/plugin-react": "^4.0.0"
+  }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import Game from './game/Game';
+
+const App: React.FC = () => {
+  return (
+    <div>
+      <h1 style={{ textAlign: 'center' }}>Robot Color Jam</h1>
+      <Game />
+    </div>
+  );
+};
+
+export default App;

--- a/src/components/Board.tsx
+++ b/src/components/Board.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { Level, RobotData } from '../game/types';
+import Robot from './Robot';
+import Exit from './Exit';
+
+interface BoardProps {
+  level: Level;
+  robots: RobotData[];
+  activeRobot: number | null;
+  onSelectRobot: (id: number) => void;
+}
+
+const Board: React.FC<BoardProps> = ({ level, robots, activeRobot, onSelectRobot }) => {
+  const gridStyle: React.CSSProperties = {
+    display: 'grid',
+    gridTemplateRows: `repeat(${level.rows}, 50px)`,
+    gridTemplateColumns: `repeat(${level.cols}, 50px)`,
+    gap: '2px',
+    backgroundColor: '#444',
+    padding: '5px',
+    margin: '0 auto',
+    width: level.cols * 52,
+  };
+
+  const cells = [];
+  for (let r = 0; r < level.rows; r++) {
+    for (let c = 0; c < level.cols; c++) {
+      cells.push({ row: r, col: c });
+    }
+  }
+
+  return (
+    <div style={gridStyle}>
+      {cells.map(cell => {
+        const robot = robots.find(r => r.row === cell.row && r.col === cell.col);
+        const exit = level.exits.find(e => e.row === cell.row && e.col === cell.col);
+        const isWall = level.walls?.some(w => w.row === cell.row && w.col === cell.col);
+
+        const cellStyle: React.CSSProperties = {
+          width: 50,
+          height: 50,
+          backgroundColor: isWall ? '#000' : '#eee',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          position: 'relative'
+        };
+
+        return (
+          <div key={`${cell.row}-${cell.col}`} style={cellStyle}>
+            {exit && <Exit color={exit.color} />}
+            {robot && (
+              <Robot
+                data={robot}
+                active={activeRobot === robot.id}
+                onSelect={() => onSelectRobot(robot.id)}
+              />
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+};
+
+export default Board;

--- a/src/components/Exit.tsx
+++ b/src/components/Exit.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+
+interface ExitProps {
+  color: string;
+}
+
+const Exit: React.FC<ExitProps> = ({ color }) => {
+  const style: React.CSSProperties = {
+    width: 40,
+    height: 40,
+    border: `2px dashed ${color}`,
+    borderRadius: 4,
+    boxSizing: 'border-box'
+  };
+
+  return <div style={style}></div>;
+};
+
+export default Exit;

--- a/src/components/Robot.tsx
+++ b/src/components/Robot.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { RobotData } from '../game/types';
+
+interface RobotProps {
+  data: RobotData;
+  active: boolean;
+  onSelect: () => void;
+}
+
+const Robot: React.FC<RobotProps> = ({ data, active, onSelect }) => {
+  const style: React.CSSProperties = {
+    width: 40,
+    height: 40,
+    borderRadius: '50%',
+    backgroundColor: data.color,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    color: '#fff',
+    cursor: 'pointer',
+    boxShadow: active ? '0 0 10px 2px gold' : undefined,
+    transition: 'box-shadow 0.2s'
+  };
+
+  return (
+    <div style={style} onClick={onSelect} title={`Robot ${data.id}`}>🤖</div>
+  );
+};
+
+export default Robot;

--- a/src/game/Game.tsx
+++ b/src/game/Game.tsx
@@ -1,0 +1,138 @@
+import React, { useState, useEffect } from 'react';
+import Board from '../components/Board';
+import { levels } from './levels';
+import { Level, RobotData, Position } from './types';
+
+// Helper function to check if two positions match
+const samePos = (a: Position, b: Position) => a.row === b.row && a.col === b.col;
+
+// Move robot until it hits obstacle or exit
+function slideRobot(
+  robot: RobotData,
+  dir: Position,
+  level: Level,
+  robots: RobotData[]
+): { robot?: RobotData; removed: boolean } {
+  let { row, col } = robot;
+  const otherRobots = robots.filter(r => r.id !== robot.id);
+
+  while (true) {
+    const nextRow = row + dir.row;
+    const nextCol = col + dir.col;
+
+    // Check walls
+    if (level.walls?.some(w => w.row === nextRow && w.col === nextCol)) break;
+
+    // Check other robots
+    if (otherRobots.some(r => r.row === nextRow && r.col === nextCol)) break;
+
+    // Check boundaries
+    if (nextRow < 0 || nextRow >= level.rows || nextCol < 0 || nextCol >= level.cols) {
+      break;
+    }
+
+    row = nextRow;
+    col = nextCol;
+
+    // Check exit
+    const exit = level.exits.find(e => e.row === row && e.col === col);
+    if (exit) {
+      if (exit.color === robot.color) {
+        return { removed: true };
+      } else {
+        // wrong color, stop before exit
+        row -= dir.row;
+        col -= dir.col;
+        break;
+      }
+    }
+  }
+
+  return { robot: { ...robot, row, col }, removed: false };
+}
+
+const Game: React.FC = () => {
+  const [levelIndex, setLevelIndex] = useState(0);
+  const [robots, setRobots] = useState<RobotData[]>(levels[0].robots);
+  const [moves, setMoves] = useState(0);
+  const [time, setTime] = useState(0);
+  const [activeRobot, setActiveRobot] = useState<number | null>(null);
+
+  const level = levels[levelIndex];
+
+  // Timer
+  useEffect(() => {
+    const id = setInterval(() => setTime(t => t + 1), 1000);
+    return () => clearInterval(id);
+  }, [levelIndex]);
+
+  // Reset level
+  const reset = () => {
+    setRobots(level.robots.map(r => ({ ...r })));
+    setMoves(0);
+    setTime(0);
+    setActiveRobot(null);
+  };
+
+  // Next level
+  const nextLevel = () => {
+    if (levelIndex < levels.length - 1) {
+      setLevelIndex(i => i + 1);
+    } else {
+      setLevelIndex(0);
+    }
+  };
+
+  // When level changes, reset robots and timer
+  useEffect(() => {
+    reset();
+  }, [levelIndex]);
+
+  // Handle movement for selected robot
+  const move = (dir: Position) => {
+    if (activeRobot === null) return;
+    const robot = robots.find(r => r.id === activeRobot);
+    if (!robot) return;
+
+    const result = slideRobot(robot, dir, level, robots);
+    setMoves(m => m + 1);
+
+    if (result.removed) {
+      setRobots(rs => rs.filter(r => r.id !== robot.id));
+    } else if (result.robot) {
+      setRobots(rs => rs.map(r => (r.id === robot.id ? result.robot! : r)));
+    }
+  };
+
+  // Win condition
+  const levelComplete = robots.length === 0;
+
+  return (
+    <div style={{ textAlign: 'center' }}>
+      <p>Level {levelIndex + 1} / {levels.length}</p>
+      <p>Time: {time}s Moves: {moves}</p>
+      <Board
+        level={level}
+        robots={robots}
+        activeRobot={activeRobot}
+        onSelectRobot={setActiveRobot}
+      />
+      <div style={{ marginTop: '10px' }}>
+        <button onClick={() => move({ row: -1, col: 0 })}>Up</button>
+        <button onClick={() => move({ row: 1, col: 0 })}>Down</button>
+        <button onClick={() => move({ row: 0, col: -1 })}>Left</button>
+        <button onClick={() => move({ row: 0, col: 1 })}>Right</button>
+      </div>
+      <div style={{ marginTop: '10px' }}>
+        <button onClick={reset}>Restart Level</button>
+        {levelComplete && (
+          <button onClick={nextLevel} style={{ marginLeft: '10px' }}>
+            Next Level
+          </button>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default Game;

--- a/src/game/levels.ts
+++ b/src/game/levels.ts
@@ -1,0 +1,56 @@
+import { Level } from './types';
+
+// Define 3 sample levels with increasing difficulty
+export const levels: Level[] = [
+  {
+    rows: 3,
+    cols: 3,
+    robots: [
+      { id: 1, row: 1, col: 1, color: 'red' },
+      { id: 2, row: 1, col: 2, color: 'blue' }
+    ],
+    exits: [
+      { row: 0, col: 1, color: 'red' },
+      { row: 2, col: 1, color: 'blue' }
+    ]
+  },
+  {
+    rows: 4,
+    cols: 4,
+    robots: [
+      { id: 1, row: 1, col: 1, color: 'red' },
+      { id: 2, row: 2, col: 2, color: 'blue' },
+      { id: 3, row: 1, col: 2, color: 'green' }
+    ],
+    exits: [
+      { row: 0, col: 3, color: 'red' },
+      { row: 3, col: 0, color: 'blue' },
+      { row: 3, col: 3, color: 'green' }
+    ],
+    walls: [
+      { row: 2, col: 1 },
+      { row: 2, col: 3 }
+    ]
+  },
+  {
+    rows: 5,
+    cols: 5,
+    robots: [
+      { id: 1, row: 2, col: 2, color: 'red' },
+      { id: 2, row: 1, col: 3, color: 'blue' },
+      { id: 3, row: 3, col: 1, color: 'green' },
+      { id: 4, row: 3, col: 3, color: 'yellow' }
+    ],
+    exits: [
+      { row: 0, col: 2, color: 'red' },
+      { row: 4, col: 4, color: 'blue' },
+      { row: 2, col: 0, color: 'green' },
+      { row: 4, col: 0, color: 'yellow' }
+    ],
+    walls: [
+      { row: 1, col: 1 },
+      { row: 2, col: 3 },
+      { row: 3, col: 2 }
+    ]
+  }
+];

--- a/src/game/types.ts
+++ b/src/game/types.ts
@@ -1,0 +1,21 @@
+export interface Position {
+  row: number;
+  col: number;
+}
+
+export interface RobotData extends Position {
+  id: number;
+  color: string;
+}
+
+export interface ExitData extends Position {
+  color: string;
+}
+
+export interface Level {
+  rows: number;
+  cols: number;
+  robots: RobotData[];
+  exits: ExitData[];
+  walls?: Position[];
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './style.css';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/src/style.css
+++ b/src/style.css
@@ -1,0 +1,16 @@
+body {
+  font-family: Arial, Helvetica, sans-serif;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+  background-color: #f0f0f0;
+}
+
+#root {
+  width: 100%;
+  display: flex;
+  justify-content: center;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "jsx": "react-jsx",
+    "moduleResolution": "Node",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src"],
+  "exclude": ["node_modules"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+});


### PR DESCRIPTION
## Summary
- create a simple React + TypeScript game inspired by Color Block Jam
- define levels and board logic with robots and exits
- add React components for board, robots, and exits
- set up Vite config and npm scripts so it can run on StackBlitz
- document usage in README

## Testing
- `npm run build` *(fails: `vite: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_688d05a39b4c832baefc141a38d2ed84